### PR TITLE
Exclude dist from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,6 +68,7 @@
     },
     "exclude": [
         "test",
-        "test-data"
+        "test-data",
+        "dist"
     ]
 }


### PR DESCRIPTION
Fixes a problem where `npm run build` complains about overwriting input files