### PR TITLE
allow 2.1 import

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@parametricos/bcf-js",
   "description": "BCF.js is a BIM Collaboration Format (BCF) reader & parser.",
   "version": "0.3.0",
-  "main": "dist/index.js",
   "type": "commonjs",
   "keywords": [
     "bim",
@@ -20,6 +19,10 @@
   "author": {
     "name": "Harry Collin",
     "email": "hc@parametricos.com"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./2.1": "./dist/2.1/index.js"
   },
   "homepage": "https://github.com/Parametricos/BCF.js#readme",
   "repository": "https://github.com/Parametricos/BCF.js",


### PR DESCRIPTION
The readme mentions

For BCF-XML 2.1:

```ts 
import { BcfReader, BcfWriter } from '@parametricos/bcf-js/2.1'
```

however this currently doesn't work. This PR uses the `exports` field in `package.json` to add it as an exported path, while keeping 3.0 as the default path.